### PR TITLE
fix the clear screen for multiplatform

### DIFF
--- a/credits.py
+++ b/credits.py
@@ -340,7 +340,12 @@ while time.time() - 2 < time_menu:
     time.sleep(0.01)
 
 
-os.system("cls")
+if os.name == "nt":
+    os.system("cls")
+elif os.name == "posix":
+    os.system("clear")
+else:
+    print("\033[2J")
 
 # wave_obj = sa.WaveObject.from_wave_file(filename)
 # play_obj = wave_obj.play()


### PR DESCRIPTION
command `cls` doesn't exist on unix/linux so i'd think it'd be better for the script to check for platform