### PR TITLE
Add screen cleanup before the skip menu. + Fixing the problem where the ocean fails to clean up after frame 4410

### DIFF
--- a/credits.py
+++ b/credits.py
@@ -307,7 +307,12 @@ playback = Playback()
 playback.load_file(filename)
 
 # Clear the console before showing the skip menu
-os.system('cls' if os.name == 'nt' else 'clear')
+if os.name == "nt":
+    os.system("cls")
+elif os.name == "posix":
+    os.system("clear")
+else:
+    print("\033[2J")
 
 print("\033[1;1Hskips\n\n1 | start\n2 | title\n3 | funding\n4 | loading\n5 | break\n6 | final")
 

--- a/credits.py
+++ b/credits.py
@@ -249,7 +249,7 @@ controller = am.SceneManager((*all_scenes, counter), (
     am.Event(3895, am.Event.swap_scene("clear")),
     am.Event(3896, am.Event.swap_scene("ocean_c")),
     *ocean2_events,
-    
+
     # remember to clean the ocean_c events up, or it will stay in the screen. At frame 4413.
     am.Event(4413, am.Event.swap_scene("clear")),
     am.Event(4460, am.Event.swap_scene("accesspoints")),
@@ -349,8 +349,12 @@ while time.time() - 2 < time_menu:
 
     time.sleep(0.01)
 
-
-os.system('cls' if os.name == 'nt' else 'clear')
+if os.name == "nt":
+    os.system("cls")
+elif os.name == "posix":
+    os.system("clear")
+else:
+    print("\033[2J")
 
 # wave_obj = sa.WaveObject.from_wave_file(filename)
 # play_obj = wave_obj.play()

--- a/credits.py
+++ b/credits.py
@@ -422,3 +422,11 @@ while playback.active:
         #         ffwing.toggle_music()
 
         last_update = time.time()
+
+# Add a final clear at the end to prevent the last frame from sticking around when the program ends.
+if os.name == "nt":
+    os.system("cls")
+elif os.name == "posix":
+    os.system("clear")
+else:
+    print("\033[2J")

--- a/credits.py
+++ b/credits.py
@@ -249,7 +249,9 @@ controller = am.SceneManager((*all_scenes, counter), (
     am.Event(3895, am.Event.swap_scene("clear")),
     am.Event(3896, am.Event.swap_scene("ocean_c")),
     *ocean2_events,
-
+    
+    # remember to clean the ocean_c events up, or it will stay in the screen. At frame 4413.
+    am.Event(4413, am.Event.swap_scene("clear")),
     am.Event(4460, am.Event.swap_scene("accesspoints")),
     am.Event(4460, am.Event.layer_scene("fdg_single")),
     am.Event(4534, lambda c: c.set_generator_data(

--- a/credits.py
+++ b/credits.py
@@ -306,6 +306,9 @@ filename = "media/credits.wav"
 playback = Playback()
 playback.load_file(filename)
 
+# Clear the console before showing the skip menu
+os.system('cls' if os.name == 'nt' else 'clear')
+
 print("\033[1;1Hskips\n\n1 | start\n2 | title\n3 | funding\n4 | loading\n5 | break\n6 | final")
 
 # Skips forward to the title scene
@@ -340,7 +343,7 @@ while time.time() - 2 < time_menu:
     time.sleep(0.01)
 
 
-os.system("cls")
+os.system('cls' if os.name == 'nt' else 'clear')
 
 # wave_obj = sa.WaveObject.from_wave_file(filename)
 # play_obj = wave_obj.play()

--- a/credits_pynput.py
+++ b/credits_pynput.py
@@ -306,6 +306,14 @@ filename = "media/credits.wav"
 playback = Playback()
 playback.load_file(filename)
 
+# Clear the console before showing the skip menu
+if os.name == "nt":
+    os.system("cls")
+elif os.name == "posix":
+    os.system("clear")
+else:
+    print("\033[2J")
+
 print("\033[1;1Hskips\n\n1 | start\n2 | title\n3 | funding\n4 | loading\n5 | break\n6 | final")
 
 # Skips forward to the title scene

--- a/credits_pynput.py
+++ b/credits_pynput.py
@@ -454,3 +454,10 @@ while playback.active:
 
         last_update = time.time()
 
+# Add a final clear at the end to prevent the last frame from sticking around when the program ends.
+if os.name == "nt":
+    os.system("cls")
+elif os.name == "posix":
+    os.system("clear")
+else:
+    print("\033[2J")

--- a/credits_pynput.py
+++ b/credits_pynput.py
@@ -249,7 +249,9 @@ controller = am.SceneManager((*all_scenes, counter), (
     am.Event(3895, am.Event.swap_scene("clear")),
     am.Event(3896, am.Event.swap_scene("ocean_c")),
     *ocean2_events,
-
+    
+    # remember to clean the ocean_c events up, or it will stay in the screen. At frame 4413.
+    am.Event(4413, am.Event.swap_scene("clear")),
     am.Event(4460, am.Event.swap_scene("accesspoints")),
     am.Event(4460, am.Event.layer_scene("fdg_single")),
     am.Event(4534, lambda c: c.set_generator_data(


### PR DESCRIPTION
Before:
<img width="900" height="271" alt="屏幕截图 2026-04-19 021034" src="https://github.com/user-attachments/assets/370194aa-e1b2-41c8-bb52-718c906cca88" />

The skip menu just mixes up with other characters on the CLI.

After:
<img width="1053" height="582" alt="屏幕截图 2026-04-19 021337" src="https://github.com/user-attachments/assets/59f6474d-7eaa-4d4c-9a05-e5c250c2c0b9" />

Much cleaner.

To my surprise, this BGA can even work on VSCode Integrated CLI.
